### PR TITLE
Allow class chaining

### DIFF
--- a/index.js
+++ b/index.js
@@ -279,7 +279,7 @@ module.exports = {
 		'selector-no-combinator': null,
 		'selector-no-id': true,
 		'selector-no-qualifying-type': [true, {
-			ignore: ['attribute']
+			ignore: ['class', 'attribute']
 		}],
 		'selector-no-type': null, // TODO: only allow in 'base' files
 		'selector-no-universal': true,


### PR DESCRIPTION
Due to the following rule, chaining classes isn't allowed: 

```
'selector-no-qualifying-type': [
    ignore: ['attribute']
}],
```

So this is invalid:

``` scss
.nav {
    &.is-open {
        // code
    }
}
```

Changing the `'selector-no-qualifying-type'` rule as proposed allows class chaining. 
We can override the rule per project, but since we use this extensively, I guess it's better to change it in the base config. 

See [stylelint docs](http://stylelint.io/user-guide/rules/selector-no-qualifying-type/)
