### PR TITLE
No unknown animations

### DIFF
--- a/index.js
+++ b/index.js
@@ -340,7 +340,7 @@ module.exports = {
 		'no-indistinguishable-colors': null, // Disabled because of: https://github.com/SlexAxton/css-colorguard/issues/32
 		'no-invalid-double-slash-comments': true,
 		'no-missing-eof-newline': true,
-		'no-unknown-animations': true,
+		'no-unknown-animations': false,
 		'no-unsupported-browser-features': null // Disabled because it does not understand 'progressive enhancement' and it's slow
 	}
 };

--- a/index.js
+++ b/index.js
@@ -279,7 +279,7 @@ module.exports = {
 		'selector-no-combinator': null,
 		'selector-no-id': true,
 		'selector-no-qualifying-type': [true, {
-			ignore: ['attribute']
+			ignore: ['class', 'attribute']
 		}],
 		'selector-no-type': null, // TODO: only allow in 'base' files
 		'selector-no-universal': true,

--- a/index.js
+++ b/index.js
@@ -340,7 +340,7 @@ module.exports = {
 		'no-indistinguishable-colors': null, // Disabled because of: https://github.com/SlexAxton/css-colorguard/issues/32
 		'no-invalid-double-slash-comments': true,
 		'no-missing-eof-newline': true,
-		'no-unknown-animations': false,
+		'no-unknown-animations': null,
 		'no-unsupported-browser-features': null // Disabled because it does not understand 'progressive enhancement' and it's slow
 	}
 };

--- a/index.js
+++ b/index.js
@@ -279,7 +279,7 @@ module.exports = {
 		'selector-no-combinator': null,
 		'selector-no-id': true,
 		'selector-no-qualifying-type': [true, {
-			ignore: ['class', 'attribute']
+			ignore: ['attribute']
 		}],
 		'selector-no-type': null, // TODO: only allow in 'base' files
 		'selector-no-universal': true,


### PR DESCRIPTION
In our structure, animations are placed in a separate scss file. Due to this the rule 
`'no-unknown-animations': true` raises an error. 

Set `'no-unknown-animations':` to `null` to support our file structure with separate animations
